### PR TITLE
1.3.0 - Added new method `get_envs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,25 @@ and this project adheres to [Semantic Versioning].
 
 - /
 
+## [1.3.0] - 2024-07-14
+
+### Added
+
+Added new method `get_envs` that returns all the environment variables set in a dict.
+```python
+    >>> settings.get_envs()
+    {'PREFIX_APP_IP': '0.0.0.0'}
+```
+
+### Fixed
+
+Fixed docstring indentation.
+
 ## [1.2.2] - 2024-03-10
 
 ## New Release v.1.2.2
 
-## Fixes
+### Fixes
 
 Fixes `TypeError: unsupported operand type(s) for |: 'type' and 'type'.` error when using Python version < 3.10
 
@@ -81,7 +95,8 @@ print(settings.mysql.databases.prod)  # Output: 'new_value'
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
 <!-- Versions -->
-[unreleased]: https://github.com/gilbn/simple-toml-configurator/compare/1.2.2...HEAD
+[unreleased]: https://github.com/gilbn/simple-toml-configurator/compare/1.3.0...HEAD
+[1.3.0]: https://github.com/gilbn/simple-toml-configurator/releases/tag/1.3.0
 [1.2.2]: https://github.com/gilbn/simple-toml-configurator/releases/tag/1.2.2
 [1.2.1]: https://github.com/gilbn/simple-toml-configurator/releases/tag/1.2.1
 [1.1.0]: https://github.com/gilbn/simple-toml-configurator/releases/tag/1.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Simple-TOML-Configurator"
-version = "1.2.2"
+version = "1.3.0"
 license = {text = "MIT License"}
 authors = [{name = "GilbN", email = "me@gilbn.dev"}]
 description = "A simple TOML configurator for Python"

--- a/src/simple_toml_configurator/__init__.py
+++ b/src/simple_toml_configurator/__init__.py
@@ -1,3 +1,3 @@
-from .toml_configurator import Configuration
+from .toml_configurator import Configuration, ConfigObject
 
 __all__ = ["Configuration"]

--- a/tests/test_toml_configurator.py
+++ b/tests/test_toml_configurator.py
@@ -270,3 +270,8 @@ def test_make_env_name_without_prefix(config_instance: Configuration):
     key = "port"
     env_name = config_instance._make_env_name(table, key)
     assert env_name == "APP_PORT"
+
+def test_get_envs(config_instance: Configuration):
+    config_instance.logging.debug = False
+    config_instance.update()
+    assert config_instance.get_envs() == {"LOGGING_DEBUG": False}


### PR DESCRIPTION
## [1.3.0] - 2024-07-14

### Added

Added new method `get_envs` that returns all the environment variables set in a dict.
```python
>>> defaults = {...}
>>> settings = Configuration()
>>> settings.init_config("config", defaults, "app_config"))
>>> settings.get_envs()
{'PREFIX_APP_IP': '0.0.0.0'}
```

### Fixed

Fixed docstring indentation.